### PR TITLE
fix: support Next 16.3.x loader-tree signature

### DIFF
--- a/packages/vitest-plugin-rsc/src/nextjs/flight-router-state.arity.test.ts
+++ b/packages/vitest-plugin-rsc/src/nextjs/flight-router-state.arity.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, expect, test, vi } from "vitest";
+
+const stub = vi.hoisted(() => {
+  const calls: unknown[][] = [];
+  const fn = (...args: unknown[]) => {
+    calls.push(args);
+    return Promise.resolve(["", {}, null, null, null] as const);
+  };
+
+  return {
+    calls,
+    fn,
+    setLength(length: number) {
+      // Function.length is `configurable: true` in ES2015+, which lets one
+      // stub simulate every Next minor without redefining or re-importing
+      // the SUT per test.
+      Object.defineProperty(fn, "length", { value: length, configurable: true });
+    },
+  };
+});
+
+vi.mock(
+  "next/dist/server/app-render/create-flight-router-state-from-loader-tree.js",
+  () => ({ createFlightRouterStateFromLoaderTree: stub.fn }),
+);
+
+const { buildFlightRouterStateWithNext } = await import("./flight-router-state.ts");
+
+beforeEach(() => {
+  stub.calls.length = 0;
+});
+
+test("dispatches Next 16.0.x/16.1.x with the 3-argument signature", async () => {
+  stub.setLength(3);
+
+  await buildFlightRouterStateWithNext("/notes/[id]", "/notes/1", "?a=1");
+
+  expect(stub.calls).toHaveLength(1);
+  const args = stub.calls[0]!;
+  expect(args).toHaveLength(3);
+  expect(Array.isArray(args[0])).toBe(true);
+  expect(typeof args[1]).toBe("function");
+  expect(args[2]).toEqual({ a: "1" });
+});
+
+test("dispatches Next 16.2.x with the 4-argument signature and a null hint tree", async () => {
+  stub.setLength(4);
+
+  await buildFlightRouterStateWithNext("/notes/[id]", "/notes/1", "");
+
+  const args = stub.calls[0]!;
+  expect(args).toHaveLength(4);
+  expect(Array.isArray(args[0])).toBe(true);
+  expect(args[1]).toBeNull();
+  expect(typeof args[2]).toBe("function");
+  expect(args[3]).toEqual({});
+});
+
+test("dispatches Next 16.3 canary with the 8-argument signature and false prerender switches", async () => {
+  stub.setLength(8);
+
+  await buildFlightRouterStateWithNext("/notes/[id]", "/notes/1", "");
+
+  const args = stub.calls[0]!;
+  expect(args).toHaveLength(8);
+  expect(args[1]).toBeNull();
+  expect(args.slice(2, 6)).toEqual([false, false, false, false]);
+  expect(typeof args[6]).toBe("function");
+  expect(args[7]).toEqual({});
+});
+
+test("dispatches Next 16.3.x with the 9-argument signature and an extra false positional", async () => {
+  stub.setLength(9);
+
+  await buildFlightRouterStateWithNext("/notes/[id]", "/notes/1", "");
+
+  const args = stub.calls[0]!;
+  expect(args).toHaveLength(9);
+  expect(args[1]).toBeNull();
+  expect(args.slice(2, 7)).toEqual([false, false, false, false, false]);
+  expect(typeof args[7]).toBe("function");
+  expect(args[8]).toEqual({});
+});

--- a/packages/vitest-plugin-rsc/src/nextjs/flight-router-state.ts
+++ b/packages/vitest-plugin-rsc/src/nextjs/flight-router-state.ts
@@ -47,11 +47,28 @@ export async function buildFlightRouterStateWithNext(
   //   booleans before the dynamic param callback. Component tests synthesize a
   //   dynamic per-test tree, so those build/runtime prerender switches are
   //   `false`.
+  // - Next 16.3.x adds one more positional boolean before the dynamic param
+  //   callback (9 arguments total), following the same "no prerender switches
+  //   during component tests" rationale.
   const loaderTree = createLoaderTree(routePattern, PAGE_SEGMENT_KEY);
   const getDynamicParamFromSegment = createGetDynamicParamFromSegment(routePattern, pathname);
   const searchParams = Object.fromEntries(new URLSearchParams(search));
   const createFlightRouterState =
     createFlightRouterStateFromLoaderTree as unknown as CreateFlightRouterStateFromLoaderTree;
+
+  if (createFlightRouterState.length >= 9) {
+    return createFlightRouterState(
+      loaderTree,
+      null,
+      false,
+      false,
+      false,
+      false,
+      false,
+      getDynamicParamFromSegment,
+      searchParams,
+    );
+  }
 
   if (createFlightRouterState.length >= 8) {
     return createFlightRouterState(


### PR DESCRIPTION
Fixes #51.

### Summary

Under Next 16.3.x, `createFlightRouterStateFromLoaderTree` grew one more positional boolean before its dynamic-param callback (arity → 9). The existing `>= 8` dispatch branch matches under 16.3.x but ships the older 8-arg vector, shifting every remaining positional and passing the callback where Next expects a boolean.

This PR adds a matching `>= 9` branch above the `>= 8` one, with the extra `false` positional. Same rationale as the neighboring booleans: component tests synthesize a dynamic per-test loader tree, so build/runtime prerender switches are always `false`.

### Change

- `packages/vitest-plugin-rsc/src/nextjs/flight-router-state.ts` — new `if (createFlightRouterState.length >= 9)` branch and matching comment. Existing branches for 3/4/8 args are unchanged.

### Regression test

`packages/vitest-plugin-rsc/src/nextjs/flight-router-state.arity.test.ts` — `vi.mock`s Next's `create-flight-router-state-from-loader-tree.js` with a single stub whose `.length` is reconfigured per test (via `Object.defineProperty`, which is legal on `Function.prototype.length`). Asserts each Next minor (3/4/8/9 args) dispatches with the correct argument vector, so all four version branches stay pinned regardless of which Next version is installed in CI.

### Verification

- `pnpm exec vitest run --configLoader runner src/nextjs/flight-router-state` inside `packages/vitest-plugin-rsc` — 10/10 pass locally (6 existing + 4 new arity tests).
- The repo's `next-compat` matrix on `canary` / `latest` (currently Next 16.3.x) should turn green with this change.

### Notes

- No changes to dispatch structure or public API — purely additive branch.
- No changeset file (repo uses Release Please, which reads Conventional Commits).
- `dist/` intentionally not touched; tsdown regenerates it on release.
- Repro referenced in the issue: https://github.com/stevez/nextcov-example/tree/rsc-poc-repro.
